### PR TITLE
fix: set userId to null

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -121,6 +121,7 @@ const resetWords = async () => {
         answer: updatedAnswer,
         mascot: null,
         solvedTimestamp: null,
+        userId: null,
       };
     });
 


### PR DESCRIPTION
This sets the `userId` to null when resetting the data.

This must be deployed with https://github.com/VGVentures/io_crossword/pull/593.